### PR TITLE
fix undefined `width` error

### DIFF
--- a/shonenjumpplus/cli.py
+++ b/shonenjumpplus/cli.py
@@ -79,7 +79,6 @@ def download(episode_uri, email, password):
                 image_bytes = response.content
                 puzzled_image = Image.open(BytesIO(image_bytes))
                 unpuzzled_image = unpuzzle_image(puzzled_image)
-                box = (0, 0, width, height)
 
                 filename = f'{str(index).zfill(4)}.jpg'
                 path = os.path.join(dirname, filename)


### PR DESCRIPTION
with this line
```python
box = (0, 0, width, height)
```
the program will raise undefined width error, I guess it's a line supposed to be commented out because width/height is handle by `unpuzzle_image`.

BTW, it's very helpful, especially the way to unpuzzle the image. Thanks for your work!